### PR TITLE
2 points to be reviewed

### DIFF
--- a/lib/src/ApiInstances.js
+++ b/lib/src/ApiInstances.js
@@ -93,17 +93,7 @@ class ApisInstance {
                     //DEBUG console.log("chain_id1",this.chain_id)
                 });
             });
-            this.ws_rpc.on_reconnect = () => {
-                this.ws_rpc.login("", "").then(() => {
-                    this._db.init().then(() => {
-                        if(this.statusCb)
-                            this.statusCb("reconnect");
-                    });
-                    this._net.init();
-                    this._hist.init();
-                    if (enableCrypto) this._crypt.init();
-                });
-            }
+
             let initPromises = [
                 db_promise,
                 this._net.init(),

--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -1,8 +1,6 @@
 let WebSocketClient;
 if (typeof WebSocket === "undefined" && !process.env.browser) {
     WebSocketClient = require("ws");
-} else if (typeof(WebSocket) !== "undefined" && typeof document !== "undefined") {
-    WebSocketClient = require("ReconnectingWebSocket")
 } else {
     WebSocketClient = WebSocket;
 }

--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -22,13 +22,11 @@ class ChainWebSocket {
         }
         this.ws.timeoutInterval = 5000;
         this.current_reject = null;
-        this.on_reconnect = null;
         this.connect_promise = new Promise((resolve, reject) => {
             this.current_reject = reject;
             this.ws.onopen = () => {
                 clearTimeout(this.connectionTimeout);
                 if(this.statusCb) this.statusCb("open");
-                if(this.on_reconnect) this.on_reconnect();
                 resolve();
             }
             this.ws.onerror = (error) => {

--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -39,10 +39,15 @@ class ChainWebSocket {
             };
             this.ws.onmessage = (message) => this.listener(JSON.parse(message.data));
             this.ws.onclose = () => {
+                var err = new Error('connection closed');
+                for(var cbId = this.responseCbId + 1; cbId <= this.cbId; cbId +=1 ){
+                    this.cbs[cbId].reject(err);
+                }
                 if(this.statusCb) this.statusCb("closed");
             };
         });
         this.cbId = 0;
+        this.responseCbId = 0;
         this.cbs = {};
         this.subs = {};
         this.unsub = {};
@@ -96,10 +101,6 @@ class ChainWebSocket {
                 resolve: resolve,
                 reject: reject
             };
-            this.ws.onerror = (error) => {
-                console.log("!!! ChainWebSocket Error ", error);
-                reject(error);
-            };
             this.ws.send(JSON.stringify(request));
         });
 
@@ -119,6 +120,7 @@ class ChainWebSocket {
 
         if (!sub) {
             callback = this.cbs[response.id];
+            this.responseCbId = response.id;
         } else {
             callback = this.subs[response.id].callback;
         }

--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -54,6 +54,9 @@ class ChainWebSocket {
     }
 
     call(params) {
+        if( this.ws.readyState != 1){
+            return Promise.reject(new Error('websocke state error:' + this.ws.readyState));
+        }
         let method = params[1];
         if(SOCKET_DEBUG)
             console.log("[ChainWebSocket] >---- call ----->  \"id\":" + (this.cbId+1), JSON.stringify(params));

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-1": "^6.16.0",
-    "ReconnectingWebSocket": "git+https://github.com/bitshares/reconnecting-websocket",
     "ws": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Please see and review my changes:

1. in browser, drop reconnectingwebsocket, and drop reconnect logic.

why this ? because the upper layer need to know when a re-connection occurs, it may re-subscibe to some markets, get some objects for notification etc etc. also, this will simplifier the difference between nodejs and browser.

2. the failed api logic. when a connection break, some api calls may neither resolved nor rejected , so the upper layer doesn't know and hangs.

   ws.onerror = xxxx , it is very dangerous as javascipt is async, the new api call will override the old
one. In my changes, added a 'virtual queue' so when a connection breaks, it rejects all promises that are not resolved so far.
