### PR TITLE
Add setAutoReconnect api in ApiInstance for some browser use case.

### DIFF
--- a/lib/src/ApiInstances.js
+++ b/lib/src/ApiInstances.js
@@ -4,7 +4,7 @@ import GrapheneApi from "./GrapheneApi";
 import ChainConfig from "./ChainConfig";
 
 let inst;
-
+let autoReconnect = true;
 /**
     Configure: configure as follows `Apis.instance("ws://localhost:8090").init_promise`.  This returns a promise, once resolved the connection is ready.
 
@@ -20,6 +20,13 @@ export default {
     setRpcConnectionStatusCallback: function(callback) {
         this.statusCb = callback;
         if(inst) inst.setRpcConnectionStatusCallback(callback);
+    },
+
+    /**
+        @arg {boolean} auto means automatic reconnect if possible( browser case), default true
+    */
+    setAutoReconnect: function ( auto ) {
+        autoReconnect = auto;
     },
 
     /**
@@ -82,7 +89,7 @@ class ApisInstance {
             throw new Error("Secure domains require wss connection");
         }
 
-        this.ws_rpc = new ChainWebSocket(cs, this.statusCb, connectTimeout);
+        this.ws_rpc = new ChainWebSocket(cs, this.statusCb, connectTimeout, autoReconnect);
 
         this.init_promise = this.ws_rpc.login(rpc_user, rpc_password).then(() => {
             console.log("Connected to API node:", cs);

--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -9,18 +9,26 @@ if (typeof WebSocket === "undefined" && !process.env.browser) {
 
 var SOCKET_DEBUG = false;
 
+function getWebSocketClient(autoReconnect){
+    if( !autoReconnect &&  (typeof(WebSocket) !== "undefined" && typeof document !== "undefined") ) {
+        return WebSocket;
+    }
+    return WebSocketClient;
+}
+
 class ChainWebSocket {
 
-    constructor(ws_server, statusCb, connectTimeout = 5000) {
+    constructor(ws_server, statusCb, connectTimeout = 5000, autoReconnect=true) {
         this.statusCb = statusCb;
         this.connectionTimeout = setTimeout(() => {
             if (this.current_reject) this.current_reject(new Error("Connection attempt timed out: " + ws_server));
         }, connectTimeout);
+        let WsClient = getWebSocketClient(autoReconnect);
         try {
-            this.ws = new WebSocketClient(ws_server);
+            this.ws = new WsClient(ws_server);
         } catch (error) {
             console.error("invalid websocket URL:", error, ws_server);
-            this.ws = new WebSocketClient("wss://127.0.0.1:8090");
+            this.ws = new WsClient("wss://127.0.0.1:8090");
         }
         this.ws.timeoutInterval = 5000;
         this.current_reject = null;


### PR DESCRIPTION
by default, in browser, it auto reconnects to websocket when broken.
but it prevent the upper layer to use another strategy (i.e. connect to
another api node in reconnecting), so add a new api to turn off the
auto-reconncting feature .