### PR TITLE
Api and socket: add keep-alive feature

### DIFF
--- a/lib/src/ApiInstances.js
+++ b/lib/src/ApiInstances.js
@@ -89,7 +89,12 @@ class ApisInstance {
             throw new Error("Secure domains require wss connection");
         }
 
-        this.ws_rpc = new ChainWebSocket(cs, this.statusCb, connectTimeout, autoReconnect);
+        this.ws_rpc = new ChainWebSocket(cs, this.statusCb, connectTimeout, autoReconnect, ()=>{
+            this._db.exec('get_objects', [['2.1.0']])
+                .catch((e)=>{
+
+                })
+        });
 
         this.init_promise = this.ws_rpc.login(rpc_user, rpc_password).then(() => {
             console.log("Connected to API node:", cs);

--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -16,9 +16,13 @@ function getWebSocketClient(autoReconnect){
     return WebSocketClient;
 }
 
+let keep_alive_interval = 5000;
+let max_send_life = 5;
+let max_recv_life = max_send_life * 2;
+
 class ChainWebSocket {
 
-    constructor(ws_server, statusCb, connectTimeout = 5000, autoReconnect=true) {
+    constructor(ws_server, statusCb, connectTimeout = 5000, autoReconnect=true, keepAliveCb=null) {
         this.statusCb = statusCb;
         this.connectionTimeout = setTimeout(() => {
             if (this.current_reject) this.current_reject(new Error("Connection attempt timed out: " + ws_server));
@@ -33,15 +37,40 @@ class ChainWebSocket {
         this.ws.timeoutInterval = 5000;
         this.current_reject = null;
         this.on_reconnect = null;
+        this.send_life = max_send_life;
+        this.recv_life = max_recv_life;
+        this.keepAliveCb = keepAliveCb;
         this.connect_promise = new Promise((resolve, reject) => {
             this.current_reject = reject;
             this.ws.onopen = () => {
                 clearTimeout(this.connectionTimeout);
                 if(this.statusCb) this.statusCb("open");
                 if(this.on_reconnect) this.on_reconnect();
+                this.keepalive_timer = setInterval(()=>{
+                    this.recv_life --;
+                    if( this.recv_life == 0){
+                        console.error('keep alive timeout.');
+                        this.ws.terminate();
+                        clearInterval(this.keepalive_timer);
+                        this.keepalive_timer = undefined;
+                        return;
+                    }
+                    this.send_life --;
+                    if( this.send_life == 0) {
+                        // this.ws.ping('', false, true);
+                        if ( this.keepAliveCb ){
+                            this.keepAliveCb();
+                        }
+                        this.send_life = max_send_life;
+                    }
+                }, 5000);
                 resolve();
             }
             this.ws.onerror = (error) => {
+                if( this.keepalive_timer ){
+                    clearInterval(this.keepalive_timer);
+                    this.keepalive_timer = undefined;
+                }
                 clearTimeout(this.connectionTimeout);
                 if(this.statusCb) this.statusCb("error");
 
@@ -49,8 +78,15 @@ class ChainWebSocket {
                     this.current_reject(error);
                 }
             };
-            this.ws.onmessage = (message) => this.listener(JSON.parse(message.data));
+            this.ws.onmessage = (message) => {
+                this.recv_life = max_recv_life;
+                this.listener(JSON.parse(message.data));
+            }
             this.ws.onclose = () => {
+                if( this.keepalive_timer ){
+                    clearInterval(this.keepalive_timer);
+                    this.keepalive_timer = undefined;
+                }
                 var err = new Error('connection closed');
                 for(var cbId = this.responseCbId + 1; cbId <= this.cbId; cbId +=1 ){
                     this.cbs[cbId].reject(err);
@@ -110,6 +146,7 @@ class ChainWebSocket {
             params: params
         };
         request.id = this.cbId;
+        this.send_life = max_send_life;
 
         return new Promise((resolve, reject) => {
             this.cbs[this.cbId] = {


### PR DESCRIPTION
Something like [this ](https://github.com/websockets/ws#how-to-detect-and-close-broken-connections) . but with two differrences:

-  the server doesn't support ping and pong , so use a real rpc call for keepalive purpose;
- if there are data exchanging recently, don't send keep-alive frame, which minimize the traffic. 
