### PR TITLE
Added concurrency limit to ConnectionManager

### DIFF
--- a/lib/src/ConnectionManager.js
+++ b/lib/src/ConnectionManager.js
@@ -77,7 +77,7 @@ class Manager {
             });
 
             Promise.all(
-                connectionPromises.map(a => a())
+                connectionPromises.map(a => a(), { concurrency: 5 })
             ).then((res) => {
                 resolve(res.filter(a => !!a).reduce((f, a) => {
                     let key = Object.keys(a)[0];


### PR DESCRIPTION
Added concurrency limit of 5 to ConnectionManager, in an effort to mitigate node list issue while in Electron. 

My first time working with this repo, so take this with a grain of salt. I built the bitshares-ui .app using package-mac script (before and after modifying the ConnectionManager). While the concurrency code does appear to make the node list load-in more slowly, I was able to reduce false positives for unreachable nodes to only those that returned actual errors (e.g. HTTP 503s).