### PR TITLE
ChainWebsocket: connection timeout behaviour fix.

### DIFF
--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -25,7 +25,17 @@ class ChainWebSocket {
     constructor(ws_server, statusCb, connectTimeout = 5000, autoReconnect=true, keepAliveCb=null) {
         this.statusCb = statusCb;
         this.connectionTimeout = setTimeout(() => {
-            if (this.current_reject) this.current_reject(new Error("Connection attempt timed out: " + ws_server));
+            if (this.current_reject) {
+                var reject = this.current_reject;
+                this.current_reject = null;
+                if( this.ws.terminate ){
+                    this.ws.terminate();
+                }
+                else{
+                    this.ws.close();
+                }
+                reject(new Error("Connection attempt timed out: " + ws_server));
+            }
         }, connectTimeout);
         let WsClient = getWebSocketClient(autoReconnect);
         try {
@@ -69,6 +79,7 @@ class ChainWebSocket {
                         this.send_life = max_send_life;
                     }
                 }, 5000);
+                this.current_reject = null;
                 resolve();
             }
             this.ws.onerror = (error) => {


### PR DESCRIPTION
1. when resolve, clean current_reject to prevent reject again.
2. when connection timeout, close websocket to avoid useless traffic.