### PR TITLE
Do not attempt get_objects if connection is closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 node_modules
 cjs
 es
+*.swp

--- a/lib/src/ApiInstances.js
+++ b/lib/src/ApiInstances.js
@@ -89,8 +89,10 @@ class ApisInstance {
             throw new Error("Secure domains require wss connection");
         }
 
-        this.ws_rpc = new ChainWebSocket(cs, this.statusCb, connectTimeout, autoReconnect, ()=>{
-            if(this._db) {
+        this.ws_rpc = new ChainWebSocket(cs, this.statusCb, connectTimeout, autoReconnect, (closed)=>{
+            if(closed) this._closed = true;
+
+            if(this._db && !closed) {
                 this._db.exec('get_objects', [['2.1.0']])
                     .catch((e)=>{
 

--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -73,7 +73,6 @@ class ChainWebSocket {
                 resolve();
             }
             this.ws.onerror = (error) => {
-                this.closed = true;
                 if( this.keepalive_timer ){
                     clearInterval(this.keepalive_timer);
                     this.keepalive_timer = undefined;

--- a/lib/src/ChainWebSocket.js
+++ b/lib/src/ChainWebSocket.js
@@ -37,6 +37,7 @@ class ChainWebSocket {
         this.ws.timeoutInterval = 5000;
         this.current_reject = null;
         this.on_reconnect = null;
+        this.closed = false;
         this.send_life = max_send_life;
         this.recv_life = max_recv_life;
         this.keepAliveCb = keepAliveCb;
@@ -64,7 +65,7 @@ class ChainWebSocket {
                     if( this.send_life == 0) {
                         // this.ws.ping('', false, true);
                         if ( this.keepAliveCb ){
-                            this.keepAliveCb();
+                            this.keepAliveCb(this.closed);
                         }
                         this.send_life = max_send_life;
                     }
@@ -72,6 +73,7 @@ class ChainWebSocket {
                 resolve();
             }
             this.ws.onerror = (error) => {
+                this.closed = true;
                 if( this.keepalive_timer ){
                     clearInterval(this.keepalive_timer);
                     this.keepalive_timer = undefined;
@@ -88,6 +90,7 @@ class ChainWebSocket {
                 this.listener(JSON.parse(message.data));
             }
             this.ws.onclose = () => {
+                this.closed = true;
                 if( this.keepalive_timer ){
                     clearInterval(this.keepalive_timer);
                     this.keepalive_timer = undefined;


### PR DESCRIPTION
This is an attempt to address an issue in bitshares-ui: https://github.com/bitshares/bitshares-ui/issues/1346

Attempting to prevent API call to get_objects if there has been a db connection timeout.