### PR TITLE
ApiInstance: when connect, clear statusCb of old ChainWebsoket

### DIFF
--- a/lib/src/ApiInstances.js
+++ b/lib/src/ApiInstances.js
@@ -89,6 +89,9 @@ class ApisInstance {
             throw new Error("Secure domains require wss connection");
         }
 
+        if( this.ws_rpc) {
+            this.ws_rpc.statusCb = null;
+        }
         this.ws_rpc = new ChainWebSocket(cs, this.statusCb, connectTimeout, autoReconnect, ()=>{
             if(this._db) {
                 this._db.exec('get_objects', [['2.1.0']])


### PR DESCRIPTION
as this lib uses single Api instance, it should not callback from old ChainWebsocket.