### PR TITLE
re-connect: set keepAliveCb of old ws_rpc to null

### DIFF
--- a/lib/src/ApiInstances.js
+++ b/lib/src/ApiInstances.js
@@ -146,11 +146,6 @@ class ApisInstance {
             if (optionalApis.enableOrders) initPromises.push(this._orders.init());
             if (optionalApis.enableCrypto) initPromises.push(this._crypt.init());
             return Promise.all(initPromises);
-        }).catch(err => {
-            console.error(cs, "Failed to initialize with error", err && err.message);
-            return this.close().then(() => {
-                throw err;
-            });
         })
     }
 


### PR DESCRIPTION
As title. I guess this may cause some timing issue, in some case I found the following error:

````
TypeError: Cannot read property 'call' of null
    at GrapheneApi.exec (/usr/src/app/node_modules/bitsharesjs-ws/cjs/src/GrapheneApi.js:25:28)
    at ChainWebSocket.keepAliveCb (/usr/src/app/node_modules/bitsharesjs-ws/cjs/src/ApiInstances.js:142:28)
    at Timeout._onTimeout (/usr/src/app/node_modules/bitsharesjs-ws/cjs/src/ChainWebSocket.js:88:35)
    at ontimeout (timers.js:482:11)
    at tryOnTimeout (timers.js:317:5)
    at Timer.listOnTimeout (timers.js:277:5)
````