### PR TITLE
Comment out connection confirmation.

### DIFF
--- a/lib/src/ApiInstances.js
+++ b/lib/src/ApiInstances.js
@@ -102,7 +102,7 @@ class ApisInstance {
             }
         });
         this.init_promise = this.ws_rpc.login(rpc_user, rpc_password).then(() => {
-            console.log("Connected to API node:", cs);
+            //console.log("Connected to API node:", cs);
             this._db = new GrapheneApi(this.ws_rpc, "database");
             this._net = new GrapheneApi(this.ws_rpc, "network_broadcast");
             this._hist = new GrapheneApi(this.ws_rpc, "history");


### PR DESCRIPTION
Commented out connection confirmation logging. 

Examples show how to log the connection success in the callback so I think it's unnecessary here (and annoying for people doing their own logging in an app using bitsharesjs-ws).